### PR TITLE
feat: Implement B&W minimalistic theme with clay buttons

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,11 +5,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius)] text-sm font-medium ring-offset-background transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground shadow-[var(--shadow-clay-sm)] hover:bg-primary/90 hover:translate-y-[-1px] hover:scale-[1.02] hover:shadow-[var(--shadow-clay-lg)]",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
+        default: "h-auto px-6 py-3",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",

--- a/src/index.css
+++ b/src/index.css
@@ -7,60 +7,60 @@
 
 @layer base {
   :root {
-    --background: 209 204 255; /* Very light grey background */
-    --foreground: 20 20 20; /* Dark charcoal text */
+    --background: 255 255 255; /* white */
+    --foreground: 0 0 0; /* black */
 
-    --card: 255 255 255; /* Pure white cards */
-    --card-foreground: 20 20 20; /* Dark text on cards */
+    --card: 250 250 250; /* very light grey */
+    --card-foreground: 0 0 0; /* black */
 
-    --popover: 255 255 255;
-    --popover-foreground: 20 20 20;
+    --popover: 250 250 250; /* very light grey */
+    --popover-foreground: 0 0 0; /* black */
 
-    --primary: 20 20 20; /* Dark charcoal primary */
-    --primary-foreground: 255 255 255; /* White text on primary */
+    --primary: 0 0 0; /* black */
+    --primary-foreground: 255 255 255; /* white */
 
-    --secondary: 245 245 245; /* Light grey secondary */
-    --secondary-foreground: 20 20 20;
+    --secondary: 240 240 240; /* light grey */
+    --secondary-foreground: 0 0 0; /* black */
 
-    --muted: 240 240 240; /* Muted grey */
-    --muted-foreground: 100 100 100; /* Medium grey text */
+    --muted: 245 245 245; /* very light grey */
+    --muted-foreground: 100 100 100; /* darker grey */
 
-    --accent: 235 235 235; /* Light accent */
-    --accent-foreground: 20 20 20;
+    --accent: 230 230 230; /* light grey */
+    --accent-foreground: 0 0 0; /* black */
 
     --destructive: 220 38 38;
     --destructive-foreground: 255 255 255;
 
-    --border: 230 230 230; /* Light border */
-    --input: 255 255 255; /* White input background */
-    --ring: 20 20 20; /* Dark focus ring */
+    --border: 220 220 220; /* light grey */
+    --input: 255 255 255; /* white */
+    --ring: 0 0 0; /* black */
 
-    --radius: 16px; /* Increased radius for clay feel */
+    --radius: 12px; /* Slightly reduced for a cleaner B&W feel, but still rounded for clay */
 
     /* Clay Shadow Variables */
-    --shadow-clay-sm: 0 2px 8px -2px rgba(0, 0, 0, 0.05), 0 1px 4px -1px rgba(0, 0, 0, 0.06);
-    --shadow-clay-md: 0 4px 16px -4px rgba(0, 0, 0, 0.08), 0 2px 8px -2px rgba(0, 0, 0, 0.04);
-    --shadow-clay-lg: 0 8px 32px -8px rgba(0, 0, 0, 0.12), 0 4px 16px -4px rgba(0, 0, 0, 0.06);
+    --shadow-clay-sm: 0 2px 8px -2px rgba(0, 0, 0, 0.08), 0 1px 4px -1px rgba(0, 0, 0, 0.08);
+    --shadow-clay-md: 0 4px 16px -4px rgba(0, 0, 0, 0.10), 0 2px 8px -2px rgba(0, 0, 0, 0.06);
+    --shadow-clay-lg: 0 8px 32px -8px rgba(0, 0, 0, 0.15), 0 4px 16px -4px rgba(0, 0, 0, 0.08);
   }
 
   .dark {
-    --background: 20 20 20;
-    --foreground: 248 248 248;
-    --card: 30 30 30;
-    --card-foreground: 248 248 248;
-    --popover: 30 30 30;
-    --popover-foreground: 248 248 248;
-    --primary: 248 248 248;
-    --primary-foreground: 20 20 20;
-    --secondary: 40 40 40;
-    --secondary-foreground: 248 248 248;
-    --muted: 50 50 50;
-    --muted-foreground: 180 180 180;
-    --accent: 60 60 60;
-    --accent-foreground: 248 248 248;
-    --border: 60 60 60;
-    --input: 30 30 30;
-    --ring: 248 248 248;
+    --background: 0 0 0; /* black */
+    --foreground: 255 255 255; /* white */
+    --card: 20 20 20; /* very dark grey */
+    --card-foreground: 255 255 255; /* white */
+    --popover: 20 20 20; /* very dark grey */
+    --popover-foreground: 255 255 255; /* white */
+    --primary: 255 255 255; /* white */
+    --primary-foreground: 0 0 0; /* black */
+    --secondary: 30 30 30; /* dark grey */
+    --secondary-foreground: 255 255 255; /* white */
+    --muted: 25 25 25; /* very dark grey */
+    --muted-foreground: 150 150 150; /* lighter grey */
+    --accent: 40 40 40; /* dark grey */
+    --accent-foreground: 255 255 255; /* white */
+    --border: 50 50 50; /* dark grey */
+    --input: 0 0 0; /* black */
+    --ring: 255 255 255; /* white */
   }
 }
 


### PR DESCRIPTION
This commit introduces a new black and white minimalistic color scheme and updates the UI to feature clay-like buttons.

Key changes:

1.  **Theme Overhaul (`src/index.css`):**
    *   Updated CSS color variables in `:root` to a black and white palette (white background, black text, and shades of grey for accents).
    *   Updated `.dark` theme to be an inverted black and white scheme (black background, white text).
    *   Adjusted global border radius (`--radius`) to `12px` for a softer, clay-like feel.

2.  **Clay Shadow Enhancement (`src/index.css`):**
    *   Modified `--shadow-clay-sm/md/lg` CSS variables to provide slightly more pronounced shadows, improving visibility on the new lighter backgrounds.

3.  **Clay Button Implementation (`src/components/ui/button.tsx`):**
    *   The default button variant now directly incorporates clay button styling:
        *   Uses primary colors (black button, white text by default).
        *   Features `var(--shadow-clay-sm)` for a subtle raised effect.
        *   Includes hover effects: slight lift (`translateY(-1px)`), gentle scale (`scale(1.02)`), and a more pronounced shadow (`var(--shadow-clay-lg)`).
        *   Padding adjusted to `px-6 py-3` for a more substantial feel.
        *   Border radius now uses `rounded-[var(--radius)]` (12px).
        *   Transitions are set to `transition-all duration-300 ease-out` for smoothness.

4.  **Tailwind Configuration (`tailwind.config.ts`):**
    *   Reviewed and confirmed that the existing `colors.clay` (greyscale) and shadow definitions are compatible with the new theme. No direct changes were needed in this file as shadow strengths were adjusted via CSS variables.

The overall aim was to create a clean, modern, and tactile user interface based on the issue requirements.