### PR TITLE
Fix: Resolve signup timeout by optimizing referral code generation

### DIFF
--- a/supabase/migrations/20231027120200_add_index_to_profiles_referral_code.sql
+++ b/supabase/migrations/20231027120200_add_index_to_profiles_referral_code.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_profiles_referral_code ON public.profiles(referral_code);

--- a/supabase/migrations/20231027120300_optimize_generate_referral_code.sql
+++ b/supabase/migrations/20231027120300_optimize_generate_referral_code.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION public.generate_referral_code()
+RETURNS TEXT AS $$
+DECLARE
+  code TEXT;
+  is_unique BOOLEAN := false;
+  max_attempts INTEGER := 10; -- Set a limit for attempts
+  attempts INTEGER := 0;
+BEGIN
+  WHILE NOT is_unique AND attempts < max_attempts LOOP
+    code := (
+        SELECT string_agg(c, '')
+        FROM (
+            SELECT unnest(string_to_array('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', NULL))
+            ORDER BY random()
+            LIMIT 6
+        ) AS dt(c)
+    );
+    -- Check if the code already exists
+    PERFORM 1 FROM public.profiles WHERE referral_code = code;
+    IF NOT FOUND THEN
+      is_unique := true;
+    END IF;
+    attempts := attempts + 1;
+  END LOOP;
+
+  IF NOT is_unique THEN
+    RAISE EXCEPTION 'Could not generate a unique referral code after % attempts. This may indicate high table contention or an issue with the generation logic.', max_attempts;
+  END IF;
+
+  RETURN code;
+END;
+$$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
This commit addresses a 504 timeout error occurring during user signup. The primary cause was identified as potential performance issues within the `handle_new_user` trigger, specifically related to the `generate_referral_code` function.

The following changes were made:

1.  **Added Index for Referral Codes:**
    - Introduced migration `20231027120200_add_index_to_profiles_referral_code.sql` to create an index on `public.profiles.referral_code`. This significantly speeds up the uniqueness check for new referral codes.

2.  **Optimized Referral Code Generation Function:**
    - Updated the `public.generate_referral_code()` function via migration `20231027120300_optimize_generate_referral_code.sql`.
    - The function now includes a maximum attempt limit (10 attempts) for generating a unique code. If it fails to find a unique code within these attempts, it raises an explicit exception instead of looping indefinitely, which prevents server timeouts and provides clearer error diagnostics.

These changes aim to make the signup process more robust and performant.