### PR TITLE
Fix: Ensure solid backgrounds for popovers and notifications

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-[100] w-72 rounded-md border-2 border-border bg-card/95 backdrop-blur-sm p-4 text-card-foreground shadow-lg outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-[100] w-72 rounded-md border-2 border-border bg-card p-4 text-card-foreground shadow-lg outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -13,7 +13,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group toast group-[.toaster]:bg-card group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
This commit addresses UI issues where popover cards and popup notifications (Sonner toasts) were appearing transparent.

Changes made:

1.  **Popover (`src/components/ui/popover.tsx`):**
    - Modified the `PopoverContent` component to use `bg-card` (a solid theme color) instead of `bg-card/95` (which had 95% opacity).
    - Removed the `backdrop-blur-sm` class, as it's not needed with a solid background.

2.  **Popup Notifications (`src/components/ui/sonner.tsx`):**
    - Updated the `toastOptions` for the Sonner `Toaster` component.
    - Changed the toast background class from `group-[.toaster]:bg-background` to `group-[.toaster]:bg-card`. This ensures toasts use the solid card background color defined in the theme.

These changes provide a more visually consistent UI by making these elements opaque, as per your feedback.