### PR TITLE
Fix: Correct RLS policy for profile creation on new user signup

### DIFF
--- a/supabase/migrations/20250618063732_fix_profile_insert_rls.sql
+++ b/supabase/migrations/20250618063732_fix_profile_insert_rls.sql
@@ -1,0 +1,7 @@
+-- Drop the existing restrictive INSERT policy
+DROP POLICY IF EXISTS "Users can insert their own profile." ON public.profiles;
+
+-- Create a new INSERT policy that allows inserts by the user themselves OR by the postgres role (for SECURITY DEFINER triggers)
+CREATE POLICY "Users can insert their own profile or system can insert via trigger." ON public.profiles
+  FOR INSERT
+  WITH CHECK ((auth.uid() = id) OR (session_user = 'postgres'));


### PR DESCRIPTION
The existing RLS policy for INSERTs on the `public.profiles` table (`"Users can insert their own profile." WITH CHECK (auth.uid() = id)`) was too restrictive for the `handle_new_user` trigger function. This function, being `SECURITY DEFINER`, executes as its owner (typically `postgres`), where `auth.uid()` might not correctly correspond to the new user's ID at the time of trigger execution, leading to failed profile insertions.

This commit introduces a new migration that modifies the INSERT policy to: `WITH CHECK ((auth.uid() = id) OR (session_user = 'postgres'))`.

This allows the `handle_new_user` trigger (running as `postgres`) to successfully insert profiles, while still allowing you to insert your own profiles directly if needed.